### PR TITLE
Add ability to set pulse interval in LED command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panel-protocol"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Jake McGinty <me@jake.su>"]
 license = "MIT"
 edition = "2018"

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -1,7 +1,7 @@
 /// A cli tool to connect to a device that talks the protocol.
 use failure::{err_msg, format_err, Error};
 use panel_protocol::{
-    ArrayVec, Command, Report, ReportReader, MAX_REPORT_LEN, MAX_REPORT_QUEUE_LEN,
+    ArrayVec, Command, PulseMode, Report, ReportReader, MAX_REPORT_LEN, MAX_REPORT_QUEUE_LEN,
 };
 use serial_core::{BaudRate, SerialDevice, SerialPortSettings};
 use serial_unix::TTYPort;
@@ -72,7 +72,13 @@ fn print_usage(args: &[String]) {
     println!("  {}", ron::ser::to_string(&Command::Brightness { target: 0, value: 0 }).unwrap());
     println!(
         "  {}",
-        ron::ser::to_string(&Command::Led { r: 255, g: 0, b: 0, pulse: true }).unwrap()
+        ron::ser::to_string(&Command::Led {
+            r: 255,
+            g: 0,
+            b: 0,
+            pulse_mode: PulseMode::Breathing { interval_ms: None }
+        })
+        .unwrap()
     );
 }
 

--- a/examples/cli.rs
+++ b/examples/cli.rs
@@ -1,3 +1,4 @@
+use core::num::NonZeroU16;
 /// A cli tool to connect to a device that talks the protocol.
 use failure::{err_msg, format_err, Error};
 use panel_protocol::{
@@ -76,7 +77,7 @@ fn print_usage(args: &[String]) {
             r: 255,
             g: 0,
             b: 0,
-            pulse_mode: PulseMode::Breathing { interval_ms: None }
+            pulse_mode: PulseMode::Breathing { interval_ms: NonZeroU16::new(4000u16).unwrap() }
         })
         .unwrap()
     );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use core::convert::{TryFrom, TryInto};
+
 pub use arrayvec::{ArrayString, ArrayVec};
 
 #[derive(Debug, PartialEq)]
@@ -8,8 +10,47 @@ pub enum Command {
     PowerCycler { slot: u8, state: bool },
     Brightness { target: u8, value: u16 },
     Temperature { target: u8, value: u16 },
-    Led { r: u8, g: u8, b: u8, pulse: bool, pulse_interval_ms: Option<u32> },
+    Led { r: u8, g: u8, b: u8, pulse_mode: PulseMode },
     Bootload, // Restart in bootloader mode.
+}
+
+#[derive(Debug, PartialEq, Clone, Copy)]
+#[cfg_attr(feature = "serde_support", derive(serde::Serialize, serde::Deserialize))]
+pub enum PulseMode {
+    Solid,
+    Breathing { interval_ms: Option<u16> }, // None -> default interval
+    DialTurn,
+}
+
+impl From<PulseMode> for [u8; 3] {
+    fn from(pulse_mode: PulseMode) -> Self {
+        match pulse_mode {
+            PulseMode::Solid => [b'S', 0, 0],
+            PulseMode::DialTurn => [b'D', 0, 0],
+            PulseMode::Breathing { interval_ms } => {
+                let interval_bytes = interval_ms.unwrap_or(0).to_be_bytes();
+                [b'B', interval_bytes[0], interval_bytes[1]]
+            },
+        }
+    }
+}
+
+impl TryFrom<[u8; 3]> for PulseMode {
+    type Error = ();
+
+    fn try_from(bytes: [u8; 3]) -> Result<Self, ()> {
+        match bytes {
+            [b'S', ..] => Ok(PulseMode::Solid),
+            [b'D', ..] => Ok(PulseMode::DialTurn),
+            [b'B', msb, lsb] => {
+                let interval_value = u16::from_be_bytes([msb, lsb]);
+                Ok(PulseMode::Breathing {
+                    interval_ms: if interval_value == 0 { None } else { Some(interval_value) },
+                })
+            },
+            _ => Err(()),
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -34,7 +75,7 @@ impl std::error::Error for Error {}
 // cmp::max(MAX_COMMAND_LEN, MAX_REPORT_LEN)
 pub const MAX_SERIAL_MESSAGE_LEN: usize = 256;
 
-pub const MAX_COMMAND_LEN: usize = 16;
+pub const MAX_COMMAND_LEN: usize = 8;
 pub const MAX_REPORT_LEN: usize = 256;
 pub const MAX_DEBUG_MSG_LEN: usize = MAX_REPORT_LEN - 2;
 pub const MAX_REPORT_QUEUE_LEN: usize = 6;
@@ -59,23 +100,10 @@ impl Command {
                 let value = u16::from_be_bytes([msb, lsb]);
                 Ok(Some((Command::Temperature { target, value }, 4)))
             },
-            [b'D', r, g, b, pulse, pi1, pi2, pi3, pi4] => {
-                let pulse_interval_ms = u32::from_be_bytes([pi1, pi2, pi3, pi4]);
-                Ok(Some((
-                    Command::Led {
-                        r,
-                        g,
-                        b,
-                        pulse: pulse != 0,
-                        pulse_interval_ms: if pulse_interval_ms != 0 {
-                            Some(pulse_interval_ms)
-                        } else {
-                            None
-                        },
-                    },
-                    9,
-                )))
-            },
+            [b'D', r, g, b, pulse_mode, pmsb, plsb, ..] => Ok(Some((
+                Command::Led { r, g, b, pulse_mode: [pulse_mode, pmsb, plsb].try_into()? },
+                7,
+            ))),
             [b'E', ..] => Ok(Some((Command::Bootload, 1))),
             [header, ..] if b"ABCD".contains(&header) => Ok(None),
             _ => Err(()),
@@ -101,17 +129,13 @@ impl Command {
                 buf.push(target);
                 buf.try_extend_from_slice(&value.to_be_bytes()).unwrap();
             },
-            Command::Led { r, g, b, pulse, pulse_interval_ms } => {
+            Command::Led { r, g, b, pulse_mode } => {
                 buf.push(b'D');
                 buf.push(r);
                 buf.push(g);
                 buf.push(b);
-                buf.push(u8::from(pulse));
-                if let Some(pulse_interval_ms) = pulse_interval_ms {
-                    buf.try_extend_from_slice(&pulse_interval_ms.to_be_bytes()).unwrap();
-                } else {
-                    buf.try_extend_from_slice(&[0; 4]).unwrap();
-                }
+                let pulse_mode_bytes: [u8; 3] = pulse_mode.into();
+                buf.try_extend_from_slice(&pulse_mode_bytes).unwrap();
             },
             Command::Bootload => buf.push(b'E'),
         }
@@ -341,7 +365,7 @@ mod tests {
             Command::PowerCycler { slot: 20, state: false },
             Command::Temperature { target: 2, value: 100 },
             Command::Brightness { target: 10, value: 100 },
-            Command::Led { r: 0, g: 128, b: 255, pulse: true },
+            Command::Led { r: 0, g: 128, b: 255, pulse_mode: PulseMode::Solid },
         ];
 
         for command in commands.iter() {
@@ -398,7 +422,7 @@ mod tests {
             Command::PowerCycler { slot: 20, state: false },
             Command::Temperature { target: 2, value: 100 },
             Command::Brightness { target: 10, value: 100 },
-            Command::Led { r: 0, g: 128, b: 255, pulse: true },
+            Command::Led { r: 0, g: 128, b: 255, pulse_mode: PulseMode::Solid },
         ];
 
         let mut bytes: ArrayVec<[u8; MAX_SERIAL_MESSAGE_LEN]> = ArrayVec::new();


### PR DESCRIPTION
This is somewhat of a very breaking change, the max command length had to be increased for this. Any thoughts on "less breaking" ways to do this or if this is fine would be great! This might be needed for the new spec for LED indication (ringing LED synced up to ringing animation), but that also could be hardcoded into the firmware and we could introduce just a mode bit into the LED command instead of the whole pulse frequency. Thoughts?