### PR TITLE
Implement fan protocol

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "panel-protocol"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Jake McGinty <me@jake.su>"]
 license = "MIT"
 edition = "2018"


### PR DESCRIPTION
Pretty simple addition to the protocol to support explicitly setting the fan speeds.

Not feature flagged as this doesn't seem to be the place to do that (as a definitions-only crate); there will be a feature flag in the `panel-firmware` binary.