### PR TITLE
Const Generics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ std = []
 serde_support = ["serde", "std"]
 
 [dependencies]
-arrayvec = { version = "0.5", default-features = false, features = ["array-sizes-129-255"] }
+arrayvec = { version = "0.7", default-features = false }
 serde = { version = "1.0", optional = true }
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "panel-protocol"
-version = "0.5.0"
-authors = ["Jake McGinty <me@jake.su>"]
+version = "0.6.0"
+authors = ["Jake McGinty <me@jake.su>", "Brian Schwind <brianmschwind@gmail.com>"]
 license = "MIT"
 edition = "2018"
 

--- a/examples/gui/panel.rs
+++ b/examples/gui/panel.rs
@@ -36,7 +36,7 @@ impl Panel {
         Ok(Self { tty, protocol, read_buf })
     }
 
-    pub fn poll(&mut self) -> Result<ArrayVec<[Report; MAX_REPORT_QUEUE_LEN]>, Error> {
+    pub fn poll(&mut self) -> Result<ArrayVec<Report, MAX_REPORT_QUEUE_LEN>, Error> {
         match self.tty.read(&mut self.read_buf) {
             Ok(0) => Err(format_err!("End of file reached")),
             Ok(count) => self

--- a/examples/gui/panel.rs
+++ b/examples/gui/panel.rs
@@ -1,7 +1,5 @@
 use anyhow::{format_err, Error, Result};
-use panel_protocol::{
-    ArrayVec, Command, Report, ReportReader, MAX_REPORT_LEN, MAX_REPORT_QUEUE_LEN,
-};
+use panel_protocol::{ArrayVec, Command, Report, ReportReader, MAX_REPORT_LEN};
 use serial_core::{BaudRate, SerialDevice, SerialPortSettings};
 use serial_unix::TTYPort;
 use std::{
@@ -10,6 +8,8 @@ use std::{
     path::PathBuf,
     time::Duration,
 };
+
+const REPORT_QUEUE_SIZE: usize = 6;
 
 static TTY_TIMEOUT: Duration = Duration::from_millis(500);
 
@@ -36,7 +36,7 @@ impl Panel {
         Ok(Self { tty, protocol, read_buf })
     }
 
-    pub fn poll(&mut self) -> Result<ArrayVec<Report, MAX_REPORT_QUEUE_LEN>, Error> {
+    pub fn poll(&mut self) -> Result<ArrayVec<Report, REPORT_QUEUE_SIZE>, Error> {
         match self.tty.read(&mut self.read_buf) {
             Ok(0) => Err(format_err!("End of file reached")),
             Ok(count) => self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ impl Command {
         }
     }
 
-    pub fn as_arrayvec(&self) -> ArrayVec<[u8; MAX_COMMAND_LEN]> {
+    pub fn as_arrayvec(&self) -> ArrayVec<u8, MAX_COMMAND_LEN> {
         let mut buf = ArrayVec::new();
 
         match *self {
@@ -156,7 +156,7 @@ impl Command {
     }
 }
 
-type DebugMessage = ArrayString<[u8; MAX_DEBUG_MSG_LEN]>;
+type DebugMessage = ArrayString<MAX_DEBUG_MSG_LEN>;
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, PartialEq)]
@@ -215,7 +215,7 @@ impl Report {
         }
     }
 
-    pub fn as_arrayvec(&self) -> ArrayVec<[u8; MAX_REPORT_LEN]> {
+    pub fn as_arrayvec(&self) -> ArrayVec<u8, MAX_REPORT_LEN> {
         let mut buf = ArrayVec::new();
 
         match *self {
@@ -283,7 +283,7 @@ where
 }
 
 pub struct ReportReader {
-    pub buf: ArrayVec<[u8; MAX_SERIAL_MESSAGE_LEN]>,
+    pub buf: ArrayVec<u8, MAX_SERIAL_MESSAGE_LEN>,
 }
 
 impl ReportReader {
@@ -294,7 +294,7 @@ impl ReportReader {
     pub fn process_bytes(
         &mut self,
         bytes: &[u8],
-    ) -> Result<ArrayVec<[Report; MAX_REPORT_QUEUE_LEN]>, Error> {
+    ) -> Result<ArrayVec<Report, MAX_REPORT_QUEUE_LEN>, Error> {
         self.buf.try_extend_from_slice(bytes).map_err(|_| Error::BufferFull)?;
 
         let mut output = ArrayVec::new();
@@ -325,7 +325,7 @@ impl Default for ReportReader {
 }
 
 pub struct CommandReader {
-    buf: ArrayVec<[u8; MAX_SERIAL_MESSAGE_LEN]>,
+    buf: ArrayVec<u8, MAX_SERIAL_MESSAGE_LEN>,
 }
 
 impl CommandReader {
@@ -336,7 +336,7 @@ impl CommandReader {
     pub fn process_bytes(
         &mut self,
         bytes: &[u8],
-    ) -> Result<ArrayVec<[Command; MAX_COMMAND_QUEUE_LEN]>, Error> {
+    ) -> Result<ArrayVec<Command, MAX_COMMAND_QUEUE_LEN>, Error> {
         self.buf.try_extend_from_slice(bytes).map_err(|_| Error::BufferFull)?;
 
         let mut output = ArrayVec::new();
@@ -427,7 +427,7 @@ mod tests {
 
         let mut protocol = ReportReader::new();
         for report_chunk in reports.chunks(MAX_REPORT_QUEUE_LEN) {
-            let mut bytes: ArrayVec<[u8; MAX_SERIAL_MESSAGE_LEN]> = ArrayVec::new();
+            let mut bytes: ArrayVec<u8, MAX_SERIAL_MESSAGE_LEN> = ArrayVec::new();
             for report in report_chunk {
                 bytes.try_extend_from_slice(&report.as_arrayvec()[..]).unwrap();
             }
@@ -457,7 +457,7 @@ mod tests {
 
         let mut protocol = CommandReader::new();
         for command_chunk in commands.chunks(MAX_COMMAND_QUEUE_LEN) {
-            let mut bytes: ArrayVec<[u8; MAX_SERIAL_MESSAGE_LEN]> = ArrayVec::new();
+            let mut bytes: ArrayVec<u8, MAX_SERIAL_MESSAGE_LEN> = ArrayVec::new();
             for command in command_chunk {
                 bytes.try_extend_from_slice(&command.as_arrayvec()[..]).unwrap();
             }


### PR DESCRIPTION
This library was written before const generics was stabilized. The underlying no-std Vec library we use (`arrayvec`), has moved to const generics already.

This also has the nice side benefit of allowing the crate consumer to specify how large of a queue they want for a command reader or report reader.

- [x] Do a full integration test with real hardware, running this code on the host and the device side