### PR TITLE
Add an optional support for defmt::Format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,13 @@ default = []
 std = []
 # This feature implements serde::{Serialize, Deserialize} for Command and Report structs.
 serde_support = ["serde", "std"]
+# This feature implements defmt::Format for Command, Report and other structs exposed by this crate.
+defmt = ["dep:defmt"]
 
 [dependencies]
 arrayvec = { version = "0.7", default-features = false }
 serde = { version = "1.0", optional = true }
+defmt = { version = "1.0", optional = true }
 
 [[example]]
 name = "cli"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub use arrayvec::ArrayVec;
 
 #[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "serde_support", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Command {
     Brightness { target: u8, value: u16 },
     Temperature { target: u8, value: u16 },
@@ -19,6 +20,7 @@ pub enum Command {
 
 #[derive(Debug, PartialEq, Clone, Copy)]
 #[cfg_attr(feature = "serde_support", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum PulseMode {
     Solid,
     Breathing { interval_ms: NonZeroU16 },
@@ -57,6 +59,7 @@ impl TryFrom<[u8; 3]> for PulseMode {
     }
 }
 #[derive(Debug)]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Error {
     BufferFull,
     MalformedMessage,
@@ -148,6 +151,7 @@ impl Command {
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "serde_support", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Report {
     DialValue { diff: i8 },
     Press,


### PR DESCRIPTION
On top of, and should be merged after #20 

Add an optional (behind a `defmt` feature) support for `defmt::Format` for `Report`, `Command` and `Error`.

This will be useful in the new dial [firmware](https://github.com/tonarino/dial-display).